### PR TITLE
docs: refresh README to actual converter pipeline + fix CITATION license (H549)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 type: software
 title: cologne-stardict
 message: If you use this software, please cite it.
-license: GPL-3.0
+license: MIT
 repository-code: https://github.com/sanskrit-lexicon/cologne-stardict
 keywords:
   - sanskrit

--- a/README.md
+++ b/README.md
@@ -1,47 +1,64 @@
 # cologne-stardict
 
-CDSL **converter** repository in the Sanskrit Lexicon project.
+_Created: 04-04-2017 · Last updated: 11-07-2026_
 
-## Issues Overview
+Scripts that convert the [Cologne Digital Sanskrit Lexicon (CDSL)](https://www.sanskrit-lexicon.uni-koeln.de/) dictionary text into [Babylon](https://en.wikipedia.org/wiki/Babylon_(software))-format source files (`*.babylon`), which are then compiled into [StarDict](https://en.wikipedia.org/wiki/StarDict) dictionaries and published in the [indic-dict/stardict-sanskrit](https://github.com/indic-dict/stardict-sanskrit) collection.
 
-**Total**: 48 | **Open**: 3 | **Closed**: 45
+This is a **converter / tooling** repository in the [sanskrit-lexicon](https://github.com/sanskrit-lexicon) org — not a dictionary itself. It transforms lexica maintained upstream; it does not author their content.
 
-### By Milestone
+## Data flow
 
-| Milestone | Open | Closed | Total |
-|---|---|---|---|
-| Unassigned | 3 | 45 | 48 |
-
-### By Type
-
-```mermaid
-pie title Issues by Type
-    "enhancement" : 28
-    "bug" : 13
-    "tech-debt" : 2
-    "feature" : 2
-    "question" : 1
+```
+csl-orig (dictionary display text)  ─┐
+hwnorm1  (headword normalization) ───┼─▶  make_babylon*.py  ─▶  output/*.babylon
+input/hwnorm1c.txt                   ─┘         │                production/*.babylon
+                                                ▼
+                                     move_to_stardict.sh
+                                                │
+                                                ▼
+                          indic-dict/stardict-sanskrit  ─▶  StarDict / GoldenDict apps
 ```
 
-### By Severity
+- **Inputs** — dictionary source text from [csl-orig](https://github.com/sanskrit-lexicon/csl-orig) and the headword-normalization table [`input/hwnorm1c.txt`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/input/hwnorm1c.txt), copied from the [hwnorm1](https://github.com/sanskrit-lexicon/hwnorm1) repo.
+- **Outputs** — [`output/`](https://github.com/sanskrit-lexicon/cologne-stardict/tree/main/output) holds development `*.babylon` files (viewing line breaks); `production/` holds production builds (HTML-style line breaks). License headers land in `output/licenses/`.
+- **Consumer** — [`move_to_stardict.sh`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/move_to_stardict.sh) deploys each production `*.babylon` into the sibling `indic-dict/stardict-sanskrit` working tree, grouped by head/entry language (`sa-head/en-entries`, `german-entries`, `french-entries`, `sa-entries`, `en-head`, …).
 
-```mermaid
-pie title Issues by Severity
-    "minor" : 31
-    "trivial" : 3
-    "major" : 2
-```
+The `main` branch is regenerated automatically after upstream `csl-orig` updates (see the commit history — e.g. "Regeneration after csl-orig commit …").
 
-## GitHub Issue Conventions
+## Dictionaries
 
-Follows the [Cologne tooling-repo taxonomy](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md):
+40+ CDSL dictionaries are registered in [`dictdata.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/dictdata.py), each mapped to its published slug and language pair (e.g. `ap` → `apte-1957` / `sa-en`, `pwg` → Böhtlingk-Roth *Großes Petersburger Wörterbuch* / `sa-de`, `gra` → Grassmann / `sa-de`). Standard dictionaries are built with `make_babylon.py`; the four synonymic/thesaurus lexica (`abch`, `acph`, `acsj`, `nmmb`) are built with `make_babylon_synonymic.py`.
 
-- **9 type labels**: bug, feature, enhancement, performance, tech-debt, security, documentation, infrastructure, question
-- **4 severity levels**: trivial, minor, major, critical
-- **5 milestones**: API Stability, User Experience, Data Quality, Developer Experience, Community
-- **Org Project**: [Tooling Roadmap](https://github.com/orgs/sanskrit-lexicon/projects/9)
+## Key scripts
 
-See [CLAUDE.md](CLAUDE.md) for full definitions.
+| File | Role |
+|---|---|
+| [`redo.sh`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/redo.sh) | Full-regeneration orchestrator: pull `hwnorm1` + `csl-orig`, refresh `input/hwnorm1c.txt`, run the converter over every registered dictionary. |
+| [`make_babylon.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/make_babylon.py) | Main converter (CDSL text → Babylon). Usage: `python3 make_babylon.py <dictId> <0|1>` — `0` = viewing (`\n` breaks), `1` = production (HTML-like breaks). |
+| [`make_babylon_synonymic.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/make_babylon_synonymic.py) | Converter variant for synonymic / thesaurus dictionaries. |
+| [`dictdata.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/dictdata.py) | Registry mapping each dictionary code → `[slug, language-pair]`. |
+| [`params.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/params.py) | Per-dictionary regex cleanup rules applied during conversion. |
+| [`fast_converter.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/fast_converter.py) | Optimized Devanagari transliteration (anusvāra → nasal-consonant variants). |
+| [`parseheadline.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/parseheadline.py) · [`utils.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/utils.py) · [`add_endline.py`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/add_endline.py) | Parsing and formatting helpers. |
+| [`copy_licence.sh`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/copy_licence.sh) | Copies each dictionary's license header from the Cologne `pywork` build into `output/licenses/` and `production/licenses/`. |
+| [`move_to_stardict.sh`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/move_to_stardict.sh) | Deploys production `*.babylon` files into the `indic-dict/stardict-sanskrit` tree. |
 
----
-*Generated by Cologne Tooling Runbook on 2026-05-15*
+`make_babylon_from_xml_unused.py` is a retired XML-based variant, kept for reference only.
+
+## Requirements
+
+- Python 3
+- [`indic_transliteration`](https://pypi.org/project/indic-transliteration/) (the `sanscript` module)
+- the [`regex`](https://pypi.org/project/regex/) module
+
+The regeneration scripts assume sibling clones of `csl-orig`, `hwnorm1`, and `indic-dict/stardict-sanskrit` next to this repository.
+
+## GitHub issue conventions
+
+This repository follows the [Cologne tooling-repo taxonomy](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md) — exactly one **type** label (bug, feature, enhancement, performance, tech-debt, security, documentation, infrastructure, question), one **severity** (trivial, minor, major, critical), and one milestone; tracked in the org [Tooling Roadmap](https://github.com/orgs/sanskrit-lexicon/projects/9). Full definitions are in [`CLAUDE.md`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/CLAUDE.md). See the [issue tracker](https://github.com/sanskrit-lexicon/cologne-stardict/issues) for current open items.
+
+## License
+
+MIT — see [`LICENSE`](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/LICENSE) (© 2017 Sanskrit Lexicon). The underlying dictionary content carries the license of each source dictionary (headers preserved under `output/licenses/`).
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
## Summary

Part of the **H549** README audit+refactor sweep across csl-* tooling repos.

The previous [README.md](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/README.md) was an auto-generated issue-stats stub (pie charts + a "Generated by Cologne Tooling Runbook" stamp) that said nothing about what the repo actually does. This rewrites it so every claim is verified against the tree at HEAD.

### Changes
- **README.md** — now documents the real data flow (`csl-orig` + `hwnorm1` → `make_babylon*.py` → `output/production/*.babylon` → `move_to_stardict.sh` → [indic-dict/stardict-sanskrit](https://github.com/indic-dict/stardict-sanskrit)), the key scripts, the `dictdata.py` dictionary registry, and build requirements. Org Markdown conventions applied: dated header (real creation date 04-04-2017 from git history), byline, full blob/tree URLs, no raw HTML.
- **CITATION.cff** — fixed the license mismatch: `GPL-3.0` → `MIT` to match the actual [LICENSE](https://github.com/sanskrit-lexicon/cologne-stardict/blob/main/LICENSE) file (© 2017 Sanskrit Lexicon).

### Verification notes
- No `readme-guard.yml` / MANUAL markers in this repo — nothing to preserve.
- No merge conflict with `main` (branched off current HEAD `72ab674`).
- The lesson-3 "referenced by csl-json build pipeline" claim was **not** confirmable — no `stardict`/`babylon` reference found in the local csl-json clone — so it was deliberately left out rather than invented. The verified consumer is `indic-dict/stardict-sanskrit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)