### PR TITLE
add/upgrade .pre-commit-config.yaml (mixed-line-ending lf)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.10
+    hooks:
+      - id: ruff
+        args: [--select=E9,F63,F7,F8]


### PR DESCRIPTION
check-yaml/end-of-file-fixer/trailing-whitespace/check-merge-conflict/mixed-line-ending --fix=lf (+ruff syntax check on Python repos). Content-aware: upgrades existing configs that lack mixed-line-ending. Per cologne_batch_deploy.py (pre-commit), H2004.